### PR TITLE
fix bar interval on split charts in vislib

### DIFF
--- a/src/plugins/vis_type_vislib/public/vislib/lib/axis/axis_scale.js
+++ b/src/plugins/vis_type_vislib/public/vislib/lib/axis/axis_scale.js
@@ -49,8 +49,17 @@ export class AxisScale {
     });
   }
 
-  getTimeDomain(data) {
+  getDomainExtent(data) {
     return [this.minExtent(data), this.maxExtent(data)];
+  }
+
+  getOrdinalDomain(values = []) {
+    if (this.ordered?.interval !== undefined) {
+      const [min, max] = this.getDomainExtent(values);
+      return _.range(min, max + this.ordered.interval, this.ordered.interval);
+    }
+
+    return values;
   }
 
   minExtent(data) {
@@ -149,8 +158,8 @@ export class AxisScale {
 
   getExtents() {
     if (this.axisConfig.get('type') === 'category') {
-      if (this.axisConfig.isTimeDomain()) return this.getTimeDomain(this.values);
-      if (this.axisConfig.isOrdinal()) return this.values;
+      if (this.axisConfig.isTimeDomain()) return this.getDomainExtent(this.values);
+      if (this.axisConfig.isOrdinal()) return this.getOrdinalDomain(this.values);
     }
 
     const min = this.axisConfig.get('scale.min', this.getYMin());


### PR DESCRIPTION
## Summary

Currently, vislib uses the _scaled_ interval to render the bars but uses a d3 ordinal scale for histogram chart scales. This may cause the actual bandwidth of the bars to be greater than the determined interval.

In the screenshot below, notice the interval is set to `5`, however when you look at the actual interval of each bar it's set to `15`. This is because the domain is determined based on the data but in order for the interval to be correct d3 needs all steps within the domain to accurately scale the bar widths. In addition, the _scaled_ interval in the case would be `4` not `15`, meaning that for the set visualization, that is the minimum interval allowable per the `histogram:maxBars` setting.

![Screen Recording 2021-01-13 at 06 31 PM](https://user-images.githubusercontent.com/19007109/104528676-84d2db80-55cd-11eb-83c0-ef604c5a67d0.gif)
