### PR TITLE
Fix filtering for small multiples

### DIFF
--- a/src/plugins/charts/public/static/utils/transform_click_event.ts
+++ b/src/plugins/charts/public/static/utils/transform_click_event.ts
@@ -41,6 +41,9 @@ export interface BrushTriggerEvent {
 
 type AllSeriesAccessors = Array<[accessor: Accessor | AccessorFn, value: string | number]>;
 
+// TODO: replace when exported from elastic/charts
+const DEFAULT_SINGLE_PANEL_SM_VALUE = '__ECH_DEFAULT_SINGLE_PANEL_SM_VALUE__';
+
 /**
  * returns accessor value from string or function accessor
  * @param datum
@@ -94,6 +97,29 @@ const getAllSplitAccessors = (
   ]);
 
 /**
+ * Gets value from small multiple accessors
+ *
+ * Only handles single small multiple accessor
+ */
+function getSplitChartValue({
+  smHorizontalAccessorValue,
+  smVerticalAccessorValue,
+}: Pick<XYChartSeriesIdentifier, 'smHorizontalAccessorValue' | 'smVerticalAccessorValue'>):
+  | string
+  | number
+  | undefined {
+  if (smHorizontalAccessorValue !== DEFAULT_SINGLE_PANEL_SM_VALUE) {
+    return smHorizontalAccessorValue;
+  }
+
+  if (smVerticalAccessorValue !== DEFAULT_SINGLE_PANEL_SM_VALUE) {
+    return smVerticalAccessorValue;
+  }
+
+  return;
+}
+
+/**
  * Reduces matching column indexes
  *
  * @param xAccessor
@@ -103,7 +129,8 @@ const getAllSplitAccessors = (
 const columnReducer = (
   xAccessor: Accessor | AccessorFn | null,
   yAccessor: Accessor | AccessorFn | null,
-  splitAccessors: AllSeriesAccessors
+  splitAccessors: AllSeriesAccessors,
+  splitChartAccessor?: Accessor | AccessorFn
 ) => (
   acc: Array<[index: number, id: string]>,
   { id }: Datatable['columns'][number],
@@ -112,6 +139,7 @@ const columnReducer = (
   if (
     (xAccessor !== null && validateAccessorId(id, xAccessor)) ||
     (yAccessor !== null && validateAccessorId(id, yAccessor)) ||
+    (splitChartAccessor !== undefined && validateAccessorId(id, splitChartAccessor)) ||
     splitAccessors.some(([accessor]) => validateAccessorId(id, accessor))
   ) {
     acc.push([index, id]);
@@ -132,13 +160,18 @@ const rowFindPredicate = (
   geometry: GeometryValue | null,
   xAccessor: Accessor | AccessorFn | null,
   yAccessor: Accessor | AccessorFn | null,
-  splitAccessors: AllSeriesAccessors
+  splitAccessors: AllSeriesAccessors,
+  splitChartAccessor?: Accessor | AccessorFn,
+  splitChartValue?: string | number
 ) => (row: Datatable['rows'][number]): boolean =>
   (geometry === null ||
     (xAccessor !== null &&
       getAccessorValue(row, xAccessor) === geometry.x &&
       yAccessor !== null &&
-      getAccessorValue(row, yAccessor) === geometry.y)) &&
+      getAccessorValue(row, yAccessor) === geometry.y &&
+      (splitChartAccessor === undefined ||
+        (splitChartValue !== undefined &&
+          getAccessorValue(row, splitChartAccessor) === splitChartValue)))) &&
   [...splitAccessors].every(([accessor, value]) => getAccessorValue(row, accessor) === value);
 
 /**
@@ -153,19 +186,28 @@ export const getFilterFromChartClickEventFn = (
   table: Datatable,
   xAccessor: Accessor | AccessorFn,
   splitSeriesAccessorFnMap?: Map<string | number, AccessorFn>,
+  splitChartAccessor?: Accessor | AccessorFn,
   negate: boolean = false
 ) => (points: Array<[GeometryValue, XYChartSeriesIdentifier]>): ClickTriggerEvent => {
   const data: ValueClickContext['data']['data'] = [];
 
   points.forEach((point) => {
     const [geometry, { yAccessor, splitAccessors }] = point;
+    const splitChartValue = getSplitChartValue(point[1]);
     const allSplitAccessors = getAllSplitAccessors(splitAccessors, splitSeriesAccessorFnMap);
     const columns = table.columns.reduce<Array<[index: number, id: string]>>(
-      columnReducer(xAccessor, yAccessor, allSplitAccessors),
+      columnReducer(xAccessor, yAccessor, allSplitAccessors, splitChartAccessor),
       []
     );
     const row = table.rows.findIndex(
-      rowFindPredicate(geometry, xAccessor, yAccessor, allSplitAccessors)
+      rowFindPredicate(
+        geometry,
+        xAccessor,
+        yAccessor,
+        allSplitAccessors,
+        splitChartAccessor,
+        splitChartValue
+      )
     );
     const newData = columns.map(([column, id]) => ({
       table,
@@ -190,16 +232,20 @@ export const getFilterFromChartClickEventFn = (
  * Helper function to get filter action event from series
  */
 export const getFilterFromSeriesFn = (table: Datatable) => (
-  { splitAccessors }: XYChartSeriesIdentifier,
+  { splitAccessors, ...rest }: XYChartSeriesIdentifier,
   splitSeriesAccessorFnMap?: Map<string | number, AccessorFn>,
+  splitChartAccessor?: Accessor | AccessorFn,
   negate = false
 ): ClickTriggerEvent => {
+  const splitChartValue = getSplitChartValue(rest);
   const allSplitAccessors = getAllSplitAccessors(splitAccessors, splitSeriesAccessorFnMap);
   const columns = table.columns.reduce<Array<[index: number, id: string]>>(
-    columnReducer(null, null, allSplitAccessors),
+    columnReducer(null, null, allSplitAccessors, splitChartAccessor),
     []
   );
-  const row = table.rows.findIndex(rowFindPredicate(null, null, null, allSplitAccessors));
+  const row = table.rows.findIndex(
+    rowFindPredicate(null, null, null, allSplitAccessors, splitChartAccessor, splitChartValue)
+  );
   const data: ValueClickContext['data']['data'] = columns.map(([column, id]) => ({
     table,
     column,

--- a/src/plugins/vis_type_xy/public/vis_component.tsx
+++ b/src/plugins/vis_type_xy/public/vis_component.tsx
@@ -129,7 +129,8 @@ const VisComponent = (props: VisComponentProps) => {
     (
       visData: Datatable,
       xAccessor: Accessor | AccessorFn,
-      splitSeriesAccessors: Array<Accessor | AccessorFn>
+      splitSeriesAccessors: Array<Accessor | AccessorFn>,
+      splitChartAccessor?: Accessor | AccessorFn
     ): ElementClickListener => {
       const splitSeriesAccessorFnMap = getSplitSeriesAccessorFnMap(splitSeriesAccessors);
       return (elements) => {
@@ -137,7 +138,8 @@ const VisComponent = (props: VisComponentProps) => {
           const event = getFilterFromChartClickEventFn(
             visData,
             xAccessor,
-            splitSeriesAccessorFnMap
+            splitSeriesAccessorFnMap,
+            splitChartAccessor
           )(elements as XYChartElementEvent[]);
           props.fireEvent(event);
         }
@@ -166,12 +168,17 @@ const VisComponent = (props: VisComponentProps) => {
     (
       visData: Datatable,
       xAccessor: Accessor | AccessorFn,
-      splitSeriesAccessors: Array<Accessor | AccessorFn>
+      splitSeriesAccessors: Array<Accessor | AccessorFn>,
+      splitChartAccessor?: Accessor | AccessorFn
     ) => {
       const splitSeriesAccessorFnMap = getSplitSeriesAccessorFnMap(splitSeriesAccessors);
       return (series: XYChartSeriesIdentifier): ClickTriggerEvent | null => {
         if (xAccessor !== null) {
-          return getFilterFromSeriesFn(visData)(series, splitSeriesAccessorFnMap);
+          return getFilterFromSeriesFn(visData)(
+            series,
+            splitSeriesAccessorFnMap,
+            splitChartAccessor
+          );
         }
 
         return null;
@@ -337,14 +344,24 @@ const VisComponent = (props: VisComponentProps) => {
           xDomain={xDomain}
           adjustedXDomain={adjustedXDomain}
           legendColorPicker={useColorPicker(legendPosition, setColor, getSeriesName)}
-          onElementClick={handleFilterClick(visData, xAccessor, splitSeriesAccessors)}
+          onElementClick={handleFilterClick(
+            visData,
+            xAccessor,
+            splitSeriesAccessors,
+            splitChartColumnAccessor ?? splitChartRowAccessor
+          )}
           onBrushEnd={handleBrush(visData, xAccessor, 'interval' in config.aspects.x.params)}
           onRenderChange={onRenderChange}
           legendAction={
             config.aspects.series && (config.aspects.series?.length ?? 0) > 0
               ? getLegendActions(
                   canFilter,
-                  getFilterEventData(visData, xAccessor, splitSeriesAccessors),
+                  getFilterEventData(
+                    visData,
+                    xAccessor,
+                    splitSeriesAccessors,
+                    splitChartColumnAccessor ?? splitChartRowAccessor
+                  ),
                   handleFilterAction,
                   getSeriesName
                 )


### PR DESCRIPTION
## Summary

The small multiples accessor was not handled in the original filter logic. This adds the functionality to filter on xy_charts with split chart accessors. Now the split chart value/column/row is included in the filter options.

![Screen Recording 2021-01-14 at 11 59 AM](https://user-images.githubusercontent.com/19007109/104630151-0d01c100-5660-11eb-8fd4-b3e027836b4f.gif)
